### PR TITLE
Install packages before running npm fund

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ganache-cli --fork https://bsc-dataseed.binance.org/ --unlock 0xd6faf697504075a3
 ## Run Scripts
 
 ```
-npm run funds && npm start
+yarn install && npm run fund && npm start
 ```
 
 ### Run the sample ui


### PR DESCRIPTION
The correct command is npm run fund not fund(s) also, dependency installation is required first.